### PR TITLE
Generate pkg-config file and add basic test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,15 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install meson libbz2-dev
+          sudo apt-get install meson libbz2-dev libglib2.0-dev
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup build
         run: meson setup build
       - name: Build library
         run: meson compile -C build/ 
+      - name: Run tests
+        run: meson test -C build/
 
   build-macos:
     name: Build (macOS)
@@ -36,6 +38,8 @@ jobs:
         run: meson setup build
       - name: Build library
         run: meson compile -C build/ 
+      - name: Run tests
+        run: meson test -C build/
 
   build-windows:
     name: Build (Windows MINGW64)
@@ -52,9 +56,12 @@ jobs:
             mingw-w64-x86_64-toolchain
             mingw-w64-x86_64-meson
             mingw-w64-x86_64-bzip2
+            mingw-w64-x86_64-glib2
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup build
         run: meson setup build
       - name: Build library
         run: meson compile -C build/ 
+      - name: Run tests
+        run: meson test -C build/

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,7 @@ cc = meson.get_compiler('c')
 
 zlib_req = '>=1.2.0'
 bzip2_req = '>=1.0.0'
+glib_req = '>=2.64.0' # only used for tests
 
 zlib_dep = dependency('zlib', version: zlib_req)
 
@@ -21,4 +22,7 @@ if not bzip2_dep.found()
     bzip2_dep = cc.find_library('bz2', has_headers: 'bzlib.h')
 endif
 
+glib_dep = dependency('glib-2.0', version: glib_req, required: false)
+
 subdir('src')
+subdir('tests')

--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,7 @@ project(
     version: '1.0.0',
 )
 
+pkg = import('pkgconfig')
 cc = meson.get_compiler('c')
 
 # Dependencies

--- a/src/meson.build
+++ b/src/meson.build
@@ -18,9 +18,8 @@ libfst = library(
     'fst',
     sources: libfst_sources,
     dependencies: libfst_dependencies,
-    # include_directories: config_inc,
-    install: true,
     version: meson.project_version(),
+    install: true,
 )
 
 libfst_dep = declare_dependency(
@@ -29,3 +28,10 @@ libfst_dep = declare_dependency(
 )
 
 install_headers(libfst_headers, subdir: 'libfst')
+
+pkg.generate(
+    name: 'libfst',
+    libraries: libfst,
+    description: 'FST reader and writer library',
+    subdirs: 'libfst',
+)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,13 @@
+libfst_tests = [
+    'write_and_read',
+]
+
+foreach test : libfst_tests
+    exe = executable(
+        'test-' + test,
+        test + '.c',
+        dependencies: [libfst_dep, glib_dep],
+    )
+
+    test(test, exe)
+endforeach

--- a/tests/write_and_read.c
+++ b/tests/write_and_read.c
@@ -1,0 +1,44 @@
+#include <fstapi.h>
+#include <glib.h>
+
+int main(int argc, char **argv)
+{
+    // Write simple FST file
+
+    void *writer = fstWriterCreate("out.fst", 1);
+    g_assert_true(writer != NULL);
+
+    fstHandle var = fstWriterCreateVar(writer, FST_VT_VCD_WIRE, FST_VD_IMPLICIT, 1, "var", 0);
+
+    fstWriterEmitTimeChange(writer, 0);
+    fstWriterEmitValueChange(writer, var, "0");
+    fstWriterEmitTimeChange(writer, 1);
+    fstWriterEmitValueChange(writer, var, "1");
+    fstWriterEmitTimeChange(writer, 2);
+
+    fstWriterClose(writer);
+
+    // Read generated FST file
+
+    void *reader = fstReaderOpen("out.fst");
+    g_assert_true(reader != NULL);
+
+    g_assert_cmpint(fstReaderGetStartTime(reader), ==, 0);
+    g_assert_cmpint(fstReaderGetEndTime(reader), ==, 2);
+    g_assert_cmpint(fstReaderGetVarCount(reader), ==, 1);
+    g_assert_cmpint(fstReaderGetScopeCount(reader), ==, 0);
+    g_assert_cmpint(fstReaderGetAliasCount(reader), ==, 0);
+
+    struct fstHier *iter = fstReaderIterateHier(reader);
+    g_assert_true(iter != NULL);
+    g_assert_cmpint(iter->htyp, ==, FST_HT_VAR);
+    g_assert_cmpstr(iter->u.var.name, ==, "var");
+    g_assert_cmpint(iter->u.var.length, ==, 1);
+
+    iter = fstReaderIterateHier(reader);
+    g_assert_true(iter == NULL);
+
+    fstReaderClose(reader);
+
+    return 0;
+}


### PR DESCRIPTION
This PR makes meson generate a pkg-config file when libfst is installed as a shared library. It also adds a first basic CI test, which just writes a basic FST file and reads it back.