### PR TITLE
Add fstWriterGetFlushContextPending to writer API.

### DIFF
--- a/src/fstapi.c
+++ b/src/fstapi.c
@@ -2536,6 +2536,18 @@ int fstWriterGetFseekFailed(void *ctx)
     return (0);
 }
 
+static int fstWriterGetFlushContextPendingInternal(void *ctx)
+{
+    struct fstWriterContext *xc = (struct fstWriterContext *)ctx;
+    return (xc->vchg_siz >= xc->fst_break_size) || (xc->flush_context_pending);
+}
+
+int fstWriterGetFlushContextPending(void *ctx)
+{
+    struct fstWriterContext *xc = (struct fstWriterContext *)ctx;
+    return xc && !xc->is_initial_time && fstWriterGetFlushContextPendingInternal(ctx);
+}
+
 /*
  * writer attr/scope/var creation:
  * fstWriterCreateVar2() is used to dump VHDL or other languages, but the
@@ -3161,7 +3173,7 @@ void fstWriterEmitTimeChange(void *ctx, uint64_t tim)
             }
             xc->is_initial_time = 0;
         } else {
-            if ((xc->vchg_siz >= xc->fst_break_size) || (xc->flush_context_pending)) {
+            if (fstWriterGetFlushContextPendingInternal(ctx)) {
                 xc->flush_context_pending = 0;
                 fstWriterFlushContextPrivate(xc);
                 xc->tchn_cnt++;

--- a/src/fstapi.c
+++ b/src/fstapi.c
@@ -2536,16 +2536,15 @@ int fstWriterGetFseekFailed(void *ctx)
     return (0);
 }
 
-static int fstWriterGetFlushContextPendingInternal(void *ctx)
+static int fstWriterGetFlushContextPendingInternal(struct fstWriterContext *xc)
 {
-    struct fstWriterContext *xc = (struct fstWriterContext *)ctx;
     return (xc->vchg_siz >= xc->fst_break_size) || (xc->flush_context_pending);
 }
 
 int fstWriterGetFlushContextPending(void *ctx)
 {
     struct fstWriterContext *xc = (struct fstWriterContext *)ctx;
-    return xc && !xc->is_initial_time && fstWriterGetFlushContextPendingInternal(ctx);
+    return xc && !xc->is_initial_time && fstWriterGetFlushContextPendingInternal(xc);
 }
 
 /*
@@ -3173,7 +3172,7 @@ void fstWriterEmitTimeChange(void *ctx, uint64_t tim)
             }
             xc->is_initial_time = 0;
         } else {
-            if (fstWriterGetFlushContextPendingInternal(ctx)) {
+            if (fstWriterGetFlushContextPendingInternal(xc)) {
                 xc->flush_context_pending = 0;
                 fstWriterFlushContextPrivate(xc);
                 xc->tchn_cnt++;

--- a/src/fstapi.h
+++ b/src/fstapi.h
@@ -420,6 +420,7 @@ void fstWriterEmitTimeChange(void *ctx, uint64_t tim);
 void fstWriterFlushContext(void *ctx);
 int fstWriterGetDumpSizeLimitReached(void *ctx);
 int fstWriterGetFseekFailed(void *ctx);
+int fstWriterGetFlushContextPending(void *ctx);
 void fstWriterSetAttrBegin(void *ctx,
                             enum fstAttrType attrtype,
                             int subtype,


### PR DESCRIPTION
This is useful for coordinating compression between multiple writer instances in parallel.

It is used by verilator/verilator#5806 to coordinate between parallel dumps.