### PR TITLE
fstReaderOpen should not fail on empty FST file

### DIFF
--- a/src/fstapi.c
+++ b/src/fstapi.c
@@ -4756,7 +4756,7 @@ fstReaderContext *fstReaderOpen(const char *nam)
             ((xc->fh) || (xc->contains_hier_section || (xc->contains_hier_section_lz4)))) {
             /* more init */
             xc->do_rewind = 1;
-        } else {
+        } else if (!rc) {
             fstReaderClose(xc);
             xc = NULL;
         }

--- a/tests/empty_file.c
+++ b/tests/empty_file.c
@@ -1,0 +1,43 @@
+#include <fstapi.h>
+#include <glib.h>
+
+int main(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    // Write empty FST file
+
+    fstWriterContext *writer = fstWriterCreate("empty1.fst", 1);
+    g_assert_true(writer != NULL);
+
+    fstWriterClose(writer);
+
+    // Should be able to open the generated FST file
+
+    fstReaderContext *reader = fstReaderOpen("empty1.fst");
+    g_assert_true(reader != NULL);
+
+    g_assert_cmpint(fstReaderGetStartTime(reader), ==, 0);
+    g_assert_cmpint(fstReaderGetEndTime(reader), ==, 0);
+    g_assert_cmpint(fstReaderGetVarCount(reader), ==, 0);
+    g_assert_cmpint(fstReaderGetScopeCount(reader), ==, 0);
+    g_assert_cmpint(fstReaderGetAliasCount(reader), ==, 0);
+
+    struct fstHier *iter = fstReaderIterateHier(reader);
+    g_assert_true(iter == NULL);
+
+    fstReaderClose(reader);
+
+    // An empty file without FST header should still fail
+
+    FILE *f = fopen("empty2.fst", "w");
+    g_assert_true(f != NULL);
+
+    fclose(f);
+
+    reader = fstReaderOpen("empty2.fst");
+    g_assert_true(reader == NULL);
+
+    return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,5 +1,6 @@
 libfst_tests = [
     'write_and_read',
+    'empty_file',
 ]
 
 foreach test : libfst_tests


### PR DESCRIPTION
I've received a couple of bug reports where users reported that GtkWave was unable to open FST files generated by NVC. This is often caused by the FST file being empty (e.g. nickg/nvc#1183 where the user accidentally excluded all signals). 

If the FST file is valid but contains no data `fstReaderOpen` returns NULL. It seems better to return a valid handle instead.